### PR TITLE
Merge remote Liberty style with local style.json and add robust fallback handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,15 +261,57 @@ const PEDESTRIAN_LAYERS = [
   }
 ];
 
-fetch("./style.json")
-  .then(r => r.json())
-  .then(style => {
-    style.layers = style.layers.map(layer => {
-      const overrides = BASE_STYLE_OVERRIDES[layer.id];
-      if (!overrides) return layer;
-      return { ...layer, paint: { ...layer.paint, ...overrides } };
+Promise.all([
+  fetch("https://tiles.openfreemap.org/styles/liberty").then(r => r.json()),
+  fetch("./style.json").then(r => r.json())
+])
+  .then(([libertyStyle, localStyle]) => {
+    const localSources = localStyle.sources || {};
+    const localLayers = localStyle.layers || [];
+    const localLayerById = new Map(localLayers.map(layer => [layer.id, layer]));
+
+    const mergedLayers = (libertyStyle.layers || []).map(layer => {
+      const localLayer = localLayerById.get(layer.id);
+      if (!localLayer) return layer;
+      return {
+        ...layer,
+        ...localLayer,
+        paint: { ...(layer.paint || {}), ...(localLayer.paint || {}) },
+        layout: { ...(layer.layout || {}), ...(localLayer.layout || {}) }
+      };
     });
-    initMap(style);
+
+    localLayers.forEach(layer => {
+      if (!mergedLayers.some(existing => existing.id === layer.id)) {
+        mergedLayers.push(layer);
+      }
+    });
+
+    const finalStyle = {
+      ...libertyStyle,
+      ...localStyle,
+      sources: { ...(libertyStyle.sources || {}), ...localSources },
+      layers: mergedLayers.map(layer => {
+        const overrides = BASE_STYLE_OVERRIDES[layer.id];
+        if (!overrides) return layer;
+        return { ...layer, paint: { ...layer.paint, ...overrides } };
+      })
+    };
+
+    initMap(finalStyle);
+  })
+  .catch(() => {
+    fetch("https://tiles.openfreemap.org/styles/liberty")
+      .then(r => r.json())
+      .then(style => {
+        style.layers = (style.layers || []).map(layer => {
+          const overrides = BASE_STYLE_OVERRIDES[layer.id];
+          if (!overrides) return layer;
+          return { ...layer, paint: { ...layer.paint, ...overrides } };
+        });
+        initMap(style);
+      })
+      .catch(() => initMap("https://tiles.openfreemap.org/styles/liberty"));
   });
 
 function initMap(style) {


### PR DESCRIPTION
### Motivation

- Allow the local `style.json` to extend and override the remote `liberty` style so map visuals can be customized while keeping the remote base style. 
- Improve resilience when fetching styles by providing fallbacks if either the remote or local fetch fails.

### Description

- Replace the single `fetch("./style.json")` flow with `Promise.all([fetch("https://tiles.openfreemap.org/styles/liberty"), fetch("./style.json")])` to load both remote and local styles.
- Merge layers by mapping remote layers and, when a local layer with the same `id` exists, merge `paint` and `layout` properties from the local layer into the remote layer, and append local-only layers to the merged set.
- Merge `sources` so local sources override remote ones and then apply `BASE_STYLE_OVERRIDES` to the final `layers` before calling `initMap`.
- Add a `.catch` fallback that attempts to load the remote `liberty` style alone and finally falls back to initializing the map with the remote style URL string if JSON fetch/parsing fails.

### Testing

- Ran `npm run build` and the build completed successfully.
- Ran `npm test` and the front-end tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de0b2703fc832a8463264ec988d5d5)