### PR TITLE
Merge remote 'liberty' base style with local style overlays and apply paint overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,16 +261,40 @@ const PEDESTRIAN_LAYERS = [
   }
 ];
 
-fetch("./style.json")
+fetch("https://tiles.openfreemap.org/styles/liberty")
   .then(r => r.json())
-  .then(style => {
-    style.layers = style.layers.map(layer => {
-      const overrides = BASE_STYLE_OVERRIDES[layer.id];
-      if (!overrides) return layer;
-      return { ...layer, paint: { ...layer.paint, ...overrides } };
-    });
-    initMap(style);
-  });
+  .then(libertyStyle => {
+    fetch("./style.json")
+      .then(r => r.json())
+      .then(localStyle => {
+        const allowedOverlayIds = new Set(Object.keys(BASE_STYLE_OVERRIDES));
+        const localOverlayPaintById = new Map(
+          (localStyle.layers || [])
+            .filter(layer => allowedOverlayIds.has(layer.id))
+            .map(layer => [layer.id, layer.paint || {}])
+        );
+
+        libertyStyle.layers = (libertyStyle.layers || []).map(layer => {
+          const localOverlayPaint = localOverlayPaintById.get(layer.id) || {};
+          const overrides = BASE_STYLE_OVERRIDES[layer.id] || {};
+          return {
+            ...layer,
+            paint: { ...(layer.paint || {}), ...localOverlayPaint, ...overrides }
+          };
+        });
+
+        initMap(libertyStyle);
+      })
+      .catch(() => {
+        libertyStyle.layers = (libertyStyle.layers || []).map(layer => {
+          const overrides = BASE_STYLE_OVERRIDES[layer.id];
+          if (!overrides) return layer;
+          return { ...layer, paint: { ...(layer.paint || {}), ...overrides } };
+        });
+        initMap(libertyStyle);
+      });
+  })
+  .catch(() => initMap("https://tiles.openfreemap.org/styles/liberty"));
 
 function initMap(style) {
   const map = new maplibregl.Map({


### PR DESCRIPTION
### Motivation

- Use the remote `https://tiles.openfreemap.org/styles/liberty` base style while allowing local style overlays to adjust paint properties.  
- Ensure `BASE_STYLE_OVERRIDES` are still applied and provide robust fallbacks when the local overlay or remote style fetch fails.  

### Description

- Replaced the single `fetch("./style.json")` call with an initial fetch of the remote liberty style and a subsequent optional fetch of `./style.json` to source local overlay paint values.  
- Build `allowedOverlayIds` from `Object.keys(BASE_STYLE_OVERRIDES)` and create `localOverlayPaintById` to collect `paint` objects from local layers that match those IDs.  
- Merge paints for each `libertyStyle` layer using the precedence `...(layer.paint || {})`, `...localOverlayPaint`, and `...overrides` so local overlays and explicit overrides take priority.  
- Add error handling so if the local style fetch fails the code still applies `BASE_STYLE_OVERRIDES`, and if the remote fetch fails it falls back to calling `initMap` with the remote style URL string.  

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de0b2703fc832a8463264ec988d5d5)