### PR TITLE
Fix state timestamp parsing and restore OSM attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ fetch("./state.txt")
     const match = txt.match(/timestamp=(.+)/);
     if (!match) return;
 
-    const iso = match[1].replace("\\:", ":");
+    const iso = match[1].trim().replace(/\\:/g, ":");
     const date = new Date(iso);
 
     const formatted = date.toLocaleString("fr-BE", {
@@ -304,6 +304,14 @@ function initMap(style) {
     zoom: 12,
     attributionControl: false
   });
+
+  map.addControl(
+    new maplibregl.AttributionControl({
+      compact: true,
+      customAttribution: ["Données © OpenStreetMap contributeurs"]
+    }),
+    "bottom-left"
+  );
 
   map.on("load", () => {
     map.addSource("pedestrian", { type: "vector", url: `pmtiles://${PMTILES_URL}` });


### PR DESCRIPTION
### Motivation
- Assurer que la date/heure extraite de `state.txt` soit correctement parsée malgré les deux-points échappés et que l’attribution obligatoire OpenStreetMap soit visible sur la carte en bas à gauche.

### Description
- Corrigé le parsing du timestamp en remplaçant toutes les séquences échappées `\:` avec `const iso = match[1].trim().replace(/\\:/g, ":");` avant `new Date(iso)` pour garantir une lecture fiable de la date et heure.
- Ajouté un contrôle d’attribution MapLibre via `map.addControl(new maplibregl.AttributionControl({...}), "bottom-left")` avec `customAttribution: ["Données © OpenStreetMap contributeurs"]` pour afficher l’attribution requise.

### Testing
- Aucun test automatisé n’est présent dans le dépôt; les modifications ont été appliquées et revues via les diffs du fichier `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1c10bdf0832ab5db33ef67f04c91)