### PR TITLE
Exclude bridge features from road casing layers

### DIFF
--- a/style.json
+++ b/style.json
@@ -40,7 +40,10 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["match", ["get", "class"], ["secondary", "tertiary"], true, false]],
+      "filter": ["all",
+        ["match", ["get", "class"], ["secondary", "tertiary"], true, false],
+        ["!=", ["get", "brunnel"], "bridge"]
+      ],
       "paint": {
         "line-color": "#111111",
         "line-width": ["interpolate", ["exponential", 1.2], ["zoom"], 8, 1.5, 20, 17]
@@ -62,7 +65,10 @@
       "type": "line",
       "source": "openmaptiles",
       "source-layer": "transportation",
-      "filter": ["all", ["match", ["get", "class"], ["primary", "trunk"], true, false]],
+      "filter": ["all",
+        ["match", ["get", "class"], ["primary", "trunk"], true, false],
+        ["!=", ["get", "brunnel"], "bridge"]
+      ],
       "paint": {
         "line-color": "#111111",
         "line-width": ["interpolate", ["exponential", 1.2], ["zoom"], 5, 0.4, 20, 22]
@@ -85,7 +91,8 @@
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": ["all",
-        ["match", ["get", "class"], ["motorway_link"], true, false]
+        ["match", ["get", "class"], ["motorway_link"], true, false],
+        ["!=", ["get", "brunnel"], "bridge"]
       ],
       "paint": {
         "line-color": "#aaaaaa",


### PR DESCRIPTION
### Motivation
- Bridge segments were rendered with dark casing lines (`brunnel=bridge`) that should be removed so bridges match the same gray fill as other roads.

### Description
- Added a filter `["!=", ["get", "brunnel"], "bridge"]` to exclude `brunnel=bridge` from the casing layers in `style.json`.
- Updated the following layers: `road_secondary_tertiary_casing`, `road_trunk_primary_casing`, and `road_motorway_link_casing`.
- No changes were made to the main road fill layers, so bridge fills remain the same gray as before.

### Testing
- Ran `python -m json.tool style.json` which completed successfully and validated the JSON syntax.
- Inspected the updated file with `git diff -- style.json` to confirm the new filter entries were added to the three casing layers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e18a567704832ab7660bd3746f2dad)